### PR TITLE
feat: added custom read_csv file configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,9 @@ These options can be placed on the root of the config or passed as `kwargs` dire
     - For example in the [pokemon sample / pokemon_species](https://github.com/kiran94/dgraphpandas/blob/e5b2864eeb285bcf4d41215f70c4675a0bc95075/samples/pokemon/dgraphpandas.json#L99-L103) file you will see a column called `evolves_from_species` which tells us for a given pokemon which other pokemon does it evolve from. If we were to use the raw data here we would get a `evolves_from_species` edge with an incorrect target xid. Instead we want to override the `target_node_type` to `pokemon` so the edge correctly loops back to a node of the same type.
 - `pre_rename`
     - Rename intrinsic predicates or edge names to something else
+- `read_csv_options`
+  - Applied to the [`pd.read_csv`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html) call when a file is passed to a transform
+  - For example if the vendor file was tab separated then this could be `{'sep': '\t'}`
 
 ## Samples
 

--- a/dgraphpandas/__init__.py
+++ b/dgraphpandas/__init__.py
@@ -1,2 +1,2 @@
 __name__ = 'dgraphpandas'
-__version__ = '0.0.6'
+__version__ = '0.0.7'

--- a/dgraphpandas/strategies/horizontal.py
+++ b/dgraphpandas/strategies/horizontal.py
@@ -33,7 +33,8 @@ def horizontal_transform(
 
     if isinstance(frame, str):
         logger.debug(f'Reading file {frame}')
-        frame = pd.read_csv(frame)
+        read_csv_options: Dict[str, Any] = get_from_config('read_csv_options', file_config, {}, **(kwargs))
+        frame = pd.read_csv(frame, **(read_csv_options))
 
     if frame.shape[1] <= len(subject_fields):
         raise ValueError(f'''

--- a/dgraphpandas/strategies/vertical.py
+++ b/dgraphpandas/strategies/vertical.py
@@ -36,7 +36,8 @@ def vertical_transform(
 
     if isinstance(frame, str):
         logger.debug(f'Reading file {frame}')
-        frame = pd.read_csv(frame)
+        read_csv_options: Dict[str, Any] = get_from_config('read_csv_options', file_config, {}, **(kwargs))
+        frame = pd.read_csv(frame, **(read_csv_options))
 
     subject_fields: Union[List[str], Callable[..., List[str]]] = get_from_config('subject_fields', file_config, **(kwargs))
     edge_fields: Union[List[str], Callable[..., List[str]]] = get_from_config('edge_fields', file_config, [], **(kwargs))


### PR DESCRIPTION
## Changes

- Added File Configuration `read_csv_options` to allow custom `pd.read_csv` options when passing a file to a transformer