### PR TITLE
feat: centralise overall rdf generation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ For Example:
 ```py
 import dgraphpandas as dpd
 
-dpd.to_rdf('your_input.csv', config, 'your_input_key' output_dir='.', export_rdf=True, chunk_size=1000)
+dpd.to_rdf('your_input.csv', config, 'your_input_key', output_dir='.', export_rdf=True, chunk_size=1000)
 ```
 
 If you wanted more control, then you could also call the underlying methods to leverage the fact that the transform methods can take a `DataFrame` directly and you can pre-chunk before you enter.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ intrinsic, edges = dpd.to_rdf('solar_system.csv', config, 'planet', output_dir='
 
 # Do something with these statements e.g write to zip and ship to DGraph
 # The cli will zip this output automatically
+# In module mode when you provide output_dir and export_rdf it will automatically zip and write to disk
 print(intrinsic)
 print(edges)
 ```
@@ -406,8 +407,6 @@ drwxr-xr-x 6 kiran kiran 4.0K Apr  4 16:45 ..
 You can then take these exports and live load them as normal.
 
 ### Module
-
-When you are using the module directly,
 
 The `chunk_size` method is also available on `to_rdf`. If you provide an `output_dir` & `export_rdf` this will automatically be written out to an export file on disk.
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ python -m pip install dgraphpandas
 ```sh
 ❯ dgraphpandas --help
 usage: dgraphpandas [-h] -f FILE -c CONFIG -ck CONFIG_FILE_KEY [-o OUTPUT_DIR]
-                    [--console] [--pre_csv] [--skip_upsert_generation]
-                    [--encoding ENCODING] [--chunk_size CHUNK_SIZE]
+                    [--console] [--export_csv] [--encoding ENCODING]
+                    [--chunk_size CHUNK_SIZE]
                     [--gz_compression_level GZ_COMPRESSION_LEVEL]
                     [--key_separator KEY_SEPARATOR]
                     [--add_dgraph_type_records ADD_DGRAPH_TYPE_RECORDS]
@@ -41,8 +41,7 @@ usage: dgraphpandas [-h] -f FILE -c CONFIG -ck CONFIG_FILE_KEY [-o OUTPUT_DIR]
                     [--drop_na_edge_objects DROP_NA_EDGE_OBJECTS]
                     [--illegal_characters ILLEGAL_CHARACTERS]
                     [--illegal_characters_intrinsic_object ILLEGAL_CHARACTERS_INTRINSIC_OBJECT]
-                    [--version]
-                    [-v {DEBUG,INFO,WARNING,ERROR,NOTSET}]
+                    [--version] [-v {DEBUG,INFO,WARNING,ERROR,NOTSET}]
 ```
 
 This is a real example which you can find in the [samples folder](https://github.com/kiran94/dgraphpandas/tree/main/samples) and run from the root of this repository:
@@ -60,9 +59,7 @@ dgraphpandas \
 This example can also be found in [Notebook](https://github.com/kiran94/dgraphpandas/blob/main/samples/notebooks/PlanetSample.ipynb) form.
 
 ```py
-from dgraphpandas.strategies.horizontal import horizontal_transform
-from dgraphpandas.strategies.vertical import vertical_transform
-from dgraphpandas.writers.upserts import generate_upserts
+import dgraphpandas as dpd
 
 # Define a Configuration for your data files(s). Explained further in the Configuration section.
 config = {
@@ -95,15 +92,22 @@ config = {
 }
 
 # Perform a Horizontal Transform on the passed file using the config/key
-intrinsic, edges = horizontal_transform('solar_system.csv', config, "planet")
-
 # Generate RDF Upsert statements
-intrinsic_upserts, edges_upserts = generate_upserts(intrinsic, edges)
+intrinsic, edges = dpd.to_rdf('solar_system.csv', config, 'planet', output_dir='.', export_rdf=True)
 
 # Do something with these statements e.g write to zip and ship to DGraph
 # The cli will zip this output automatically
 print(intrinsic)
 print(edges)
+```
+
+Alternatively, you could call the underlying methods
+
+```py
+# Perform a Horizontal Transform on the passed file using the config/key
+intrinsic, edges = horizontal_transform('solar_system.csv', config, "planet")
+# Generate RDF Upsert statements
+intrinsic_upserts, edges_upserts = generate_upserts(intrinsic, edges)
 ```
 
 ## Getting Started
@@ -403,9 +407,19 @@ You can then take these exports and live load them as normal.
 
 ### Module
 
-When you are using the module directly, you can leverage the fact that the transform methods can take a `DataFrame` directly and you can pre-chunk before they enter.
+When you are using the module directly,
+
+The `chunk_size` method is also available on `to_rdf`. If you provide an `output_dir` & `export_rdf` this will automatically be written out to an export file on disk.
 
 For Example:
+
+```py
+import dgraphpandas as dpd
+
+dpd.to_rdf('your_input.csv', config, 'your_input_key' output_dir='.', export_rdf=True, chunk_size=1000)
+```
+
+If you wanted more control, then you could also call the underlying methods to leverage the fact that the transform methods can take a `DataFrame` directly and you can pre-chunk before you enter.
 
 ```py
 from dgraphpandas.strategies.horizontal import horizontal_transform

--- a/dgraphpandas/__init__.py
+++ b/dgraphpandas/__init__.py
@@ -1,3 +1,5 @@
 __name__ = 'dgraphpandas'
-__version__ = '0.0.12'
+__version__ = '0.1.0'
 __description__ = 'Transform Pandas DataFrames into Exports to be sent to DGraph'
+
+from dgraphpandas.rdf import to_rdf  # noqa

--- a/dgraphpandas/__main__.py
+++ b/dgraphpandas/__main__.py
@@ -1,17 +1,13 @@
 import logging
 import argparse
 import os
-import gzip
 import json
 from typing import Any, Dict
 from pprint import pformat
 
 import pandas as pd
 
-from dgraphpandas import __version__, __description__
-from dgraphpandas.strategies.horizontal import horizontal_transform
-from dgraphpandas.strategies.vertical import vertical_transform
-from dgraphpandas.writers.upserts import generate_upserts
+from dgraphpandas import __version__, __description__, to_rdf
 
 pd.set_option('mode.chained_assignment', None)
 
@@ -23,11 +19,11 @@ def main():
     parser.add_argument('-ck', '--config_file_key', required=True, help='The Entry in the Configuration to use for this passed file.')
     parser.add_argument('-o', '--output_dir', default='.', help='The output directory to write files.')
     parser.add_argument('--console', action='store_true', default=False, help='Write the Preprocessed DataFrames to console (for debugging)')
-    parser.add_argument('--pre_csv', action='store_true', default=False, help='Write the Preprocessed DataFrame to CSV (for debugging)')
-    parser.add_argument('--skip_upsert_generation', action='store_true', default=False, help="Don't generate RDF files")
+    parser.add_argument('--export_csv', action='store_true', default=False, help='Write the Preprocessed DataFrame to CSV (for debugging)')
     parser.add_argument('--encoding', default=os.environ.get('DGRAPHPANDAS_ENCODING', 'utf-8'), help='The Encoding to write files.')
     parser.add_argument('--chunk_size', default=10_000_000, type=int, help='Process and output in chunks rather all at once')
     parser.add_argument('--gz_compression_level', default=9, type=int, help='Compression level to set output gzip files to')
+
     parser.add_argument('--key_separator')
     parser.add_argument('--add_dgraph_type_records', default=True)
     parser.add_argument('--drop_na_intrinsic_objects', default=True)
@@ -50,83 +46,24 @@ def main():
     except ImportError as e:
         logger.debug(e)
 
-    with open(args.config, 'r') as f:
-        global_config: Dict[str, Any] = json.load(f)
-        logger.debug('Global Config \n %s', pformat(global_config))
-
     options = {
         'key_separator': args.key_separator,
         'add_dgraph_type_records': args.add_dgraph_type_records,
         'drop_na_intrinsic_objects': args.drop_na_intrinsic_objects,
         'drop_na_edge_objects': args.drop_na_edge_objects,
         'illegal_characters': args.illegal_characters,
-        'illegal_characters_intrinsic_object': args.illegal_characters_intrinsic_object
+        'illegal_characters_intrinsic_object': args.illegal_characters_intrinsic_object,
+        'console': args.console,
+        'export_csv': args.export_csv,
+        'chunk_size': args.chunk_size
     }
     options = {key: value for key, value in options.items() if value is not None and value is not False}
 
-    if global_config['transform'] == 'horizontal':
-        transform_func = horizontal_transform
-    elif global_config['transform'] == 'vertical':
-        transform_func = vertical_transform
-    else:
-        raise NotImplementedError(global_config['transform'])
+    with open(args.config, 'r') as f:
+        global_config: Dict[str, Any] = json.load(f)
+        logger.debug('Global Config \n %s', pformat(global_config))
 
-    for index, frame in enumerate(pd.read_csv(args.file, chunksize=args.chunk_size)):
-        index += 1
-        logger.info(f'Processing Chunk {index} with {frame.shape[0]} rows')
-
-        intrinsic, edges = transform_func(args.file, global_config, args.config_file_key, **(options))
-
-        if args.console and index == 1:
-            print('Intrinsic:')
-            print(intrinsic)
-            print('Edges:')
-            print(edges)
-        else:
-            logger.debug('Console only enabled for first chunk, skipping.')
-
-        source_file_name = os.path.basename(args.file).split('.')[0]
-        if index == 1:
-            intrinsic_base_path = os.path.join(args.output_dir, source_file_name + '_intrinsic')
-            edges_base_path = os.path.join(args.output_dir, source_file_name + '_edges')
-        else:
-            intrinsic_base_path = os.path.join(args.output_dir, source_file_name + '_intrinsic_' + str(index))
-            edges_base_path = os.path.join(args.output_dir, source_file_name + '_edges_' + str(index))
-
-        if args.pre_csv:
-            os.makedirs(args.output_dir, exist_ok=True)
-
-            intrinsic_csv_path = intrinsic_base_path + '.csv'
-            edges_csv_path = edges_base_path + '.csv'
-
-            logger.info(f'Writing to {intrinsic_csv_path}')
-            intrinsic.to_csv(intrinsic_csv_path, index=False, encoding=args.encoding)
-
-            logger.info(f'Writing to {edges_csv_path}')
-            edges.to_csv(edges_csv_path, index=False, encoding=args.encoding)
-
-        if not args.skip_upsert_generation:
-            logger.info('Generating Upsert Queries')
-            intrinsic_upserts, edges_upserts = generate_upserts(intrinsic, edges)
-
-            os.makedirs(args.output_dir, exist_ok=True)
-            intrinsic_gz_path = intrinsic_base_path + '.gz'
-            edges_gz_path = edges_base_path + '.gz'
-
-            logger.info(f'Writing to {len(intrinsic_upserts)} upserts to {intrinsic_gz_path}')
-            with gzip.open(intrinsic_gz_path, mode='wb', compresslevel=args.gz_compression_level) as zip:
-                s = '\n'.join(intrinsic_upserts)
-                s = s.encode(encoding=args.encoding)
-                zip.write(s)
-
-            logger.info(f'Writing to {len(edges_upserts)} upserts to {edges_gz_path}')
-            with gzip.open(edges_gz_path, mode='wb', compresslevel=args.gz_compression_level) as zip:
-                s = '\n'.join(edges_upserts)
-                s = s.encode(encoding=args.encoding)
-                zip.write(s)
-
-        else:
-            logger.warning('skip_upsert_generation was set, skipping')
+    to_rdf(args.file, global_config, args.config_file_key, args.output_dir, export_rdf=True, **(options))
 
 
 if __name__ == '__main__':

--- a/dgraphpandas/config.py
+++ b/dgraphpandas/config.py
@@ -1,5 +1,9 @@
+import json
+import logging
+from pprint import pformat
+from typing import Dict, Any, Union
 
-from typing import Dict, Any
+logger = logging.getLogger(__name__)
 
 
 def get_from_config(key: str, config: Dict[str, Any], default: Any = None, **kwargs) -> Any:
@@ -10,8 +14,26 @@ def get_from_config(key: str, config: Dict[str, Any], default: Any = None, **kwa
     else return default
     '''
     if not key:
-        raise ValueError(key)
+        raise ValueError('key')
     if not config:
-        raise ValueError(config)
+        raise ValueError('config')
 
     return kwargs.get(key, config.get(key, default))
+
+
+def _get_config(config: Union[str, Dict[str, Any]]) -> Dict[str, Any]:
+    '''
+    The Configuration may be a file path or already loaded config.
+    If it's a string then attempt to load it first.
+    '''
+    if config is None:
+        raise ValueError('config')
+
+    if isinstance(config, str):
+        logger.info(f'Reading from configuration {config}')
+        with open(config, 'r') as f:
+            config: Dict[str, Any] = json.load(f)
+            logger.debug('Global Config \n %s', pformat(config))
+        return config
+    else:
+        return config

--- a/dgraphpandas/rdf.py
+++ b/dgraphpandas/rdf.py
@@ -47,10 +47,12 @@ def to_rdf(
         frame: A Pandas DataFrame or file path to a CSV to be converted.
         config: A Configuration Dictionary or file path
         config_key: The file (key) to use in the configuration
+        output_dir: The output directory to push exports. If none, don't export
 
     Returns:
-        None if the output_dir was supplied as the data was written to disk
-        else a Tuple of the intrinsic and edges
+        If chunking was applied then a list of tuples
+        If no chunking then just a tuple
+        Each tuple has two items: intrinsic and edges
     '''
     if frame is None:
         raise ValueError('frame')

--- a/dgraphpandas/rdf.py
+++ b/dgraphpandas/rdf.py
@@ -1,0 +1,143 @@
+import os
+import logging
+import gzip
+from typing import Any, Dict, Union, Tuple, List, Callable
+
+import pandas as pd
+
+from dgraphpandas.config import get_from_config, _get_config
+from dgraphpandas.writers.upserts import generate_upserts
+from dgraphpandas.strategies.vertical import vertical_transform
+from dgraphpandas.strategies.horizontal import horizontal_transform
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_transform(config: Dict[str, Any]):
+    '''
+    Based on the transform configuration, choose
+    a transform function
+    '''
+    if config is None:
+        raise ValueError('config')
+    if 'transform' not in config:
+        return horizontal_transform
+
+    if config['transform'] == 'horizontal':
+        transform_func = horizontal_transform
+    elif config['transform'] == 'vertical':
+        transform_func = vertical_transform
+    else:
+        logger.debug('Transform not set within configuration, defaulting to horizontal')
+        transform_func = horizontal_transform
+
+    return transform_func
+
+
+def to_rdf(
+        frame: Union[str, pd.DataFrame],
+        config: Union[Dict[str, Any], str],
+        config_key: str,
+        output_dir: Union[str, None] = None,
+        **kwargs) -> Union[None, List[Tuple[List[str], List[str]]]]:
+    '''
+    Converts a Pandas DataFrame into RDF Exports.
+
+    Parameters:
+        frame: A Pandas DataFrame or file path to a CSV to be converted.
+        config: A Configuration Dictionary or file path
+        config_key: The file (key) to use in the configuration
+
+    Returns:
+        None if the output_dir was supplied as the data was written to disk
+        else a Tuple of the intrinsic and edges
+    '''
+    if frame is None:
+        raise ValueError('frame')
+    if not config:
+        raise ValueError('config')
+    if not config_key:
+        raise ValueError('config_key')
+
+    config = _get_config(config)
+    transform_func = _resolve_transform(config)
+
+    '''
+    The Frame may be a file path or already loaded DataFrame.
+    If it's a string then attempt to load the file.
+    '''
+    if isinstance(frame, str):
+        file_config = config['files'][config_key]
+        read_csv_options: Dict[str, Any] = get_from_config('read_csv_options', file_config, {}, **(kwargs))
+        chunk_size: int = get_from_config('chunk_size', config, 10_000_000, **(kwargs))
+        source_file_name = os.path.basename(frame).split('.')[0]
+
+        result = []
+        for index, frame in enumerate(pd.read_csv(frame, chunksize=chunk_size, **(read_csv_options))):
+            result.append(to_rdf_from_frame(frame, config, config_key, transform_func, source_file_name, output_dir, index, **(kwargs)))
+        return result
+    else:
+        return to_rdf_from_frame(frame, config, config_key, transform_func, config_key, output_dir, 0, **(kwargs))
+
+
+def to_rdf_from_frame(
+        frame: pd.DataFrame,
+        config: Dict[str, Any],
+        config_key,
+        transform_func: Callable,
+        source_file_name: str,
+        output_dir: str,
+        index: int = 0,
+        **kwargs):
+
+    file_config = config['files'][config_key]
+    console: bool = get_from_config('console', config, False, **(kwargs))
+    export_csv: bool = get_from_config('export_csv', file_config, False, **(kwargs))
+    export_rdf: bool = get_from_config('export_rdf', file_config, False, **(kwargs))
+    encoding: str = get_from_config('encoding', file_config, 'utf-8', **(kwargs))
+    gz_compression_level: int = get_from_config('gz_compression_level', file_config, 9, **(kwargs))
+
+    logger.info('Transforming Source Frame to Rdf Frame')
+    intrinsic, edges = transform_func(frame, config, config_key, **(kwargs))
+    if console:
+        print('Intrinsic \n', intrinsic)
+        print('Edges \n', edges)
+
+    intrinsic_upserts, edges_upserts = generate_upserts(intrinsic, edges)
+    if output_dir is not None:
+        os.makedirs(output_dir, exist_ok=True)
+        if index == 0:
+            intrinsic_base_path = os.path.join(output_dir, source_file_name + '_intrinsic')
+            edges_base_path = os.path.join(output_dir, source_file_name + '_edges')
+        else:
+            intrinsic_base_path = os.path.join(output_dir, source_file_name + '_intrinsic_' + str(index+1))
+            edges_base_path = os.path.join(output_dir, source_file_name + '_edges_' + str(index+1))
+
+        if export_csv:
+            intrinsic_csv_path = intrinsic_base_path + '.csv'
+            edges_csv_path = edges_base_path + '.csv'
+
+            logger.info(f'Writing to {intrinsic_csv_path}')
+            intrinsic.to_csv(intrinsic_csv_path, index=False, encoding=encoding)
+
+            logger.info(f'Writing to {edges_csv_path}')
+            edges.to_csv(edges_csv_path, index=False, encoding=encoding)
+
+        if export_rdf:
+            logger.info('Generating Rdf Upserts from Frames')
+
+            intrinsic_gz_path = intrinsic_base_path + '.gz'
+            logger.info(f'Writing to {len(intrinsic_upserts)} upserts to {intrinsic_gz_path}')
+            with gzip.open(intrinsic_gz_path, mode='wb', compresslevel=gz_compression_level) as zip:
+                s = '\n'.join(intrinsic_upserts)
+                s = s.encode(encoding=encoding)
+                zip.write(s)
+
+            edges_gz_path = edges_base_path + '.gz'
+            logger.info(f'Writing to {len(edges_upserts)} upserts to {edges_gz_path}')
+            with gzip.open(edges_gz_path, mode='wb', compresslevel=gz_compression_level) as zip:
+                s = '\n'.join(edges_upserts)
+                s = s.encode(encoding=encoding)
+                zip.write(s)
+
+    return intrinsic_upserts, edges_upserts

--- a/tests/strategies/test_vertical.py
+++ b/tests/strategies/test_vertical.py
@@ -964,17 +964,17 @@ class Vertical(unittest.TestCase):
         try:
             assert_frame_equal(expected_intrinsic, intrinsic)
             assert_frame_equal(expected_edges, edges)
-        except AssertionError:
-            print('Failed', name)
-            print('Input:')
-            print(input_frame)
-            print('Expected Intrinsic:')
-            print(expected_intrinsic)
-            print('Intrinsic:')
-            print(intrinsic)
-            print('#####')
-            print('Expected Edges:')
-            print(expected_edges)
-            print('Edges:')
-            print(edges)
-            raise
+        except AssertionError:  # pragma: no cover
+            print('Failed', name)  # pragma: no cover
+            print('Input:')  # pragma: no cover
+            print(input_frame)  # pragma: no cover
+            print('Expected Intrinsic:')  # pragma: no cover
+            print(expected_intrinsic)  # pragma: no cover
+            print('Intrinsic:')  # pragma: no cover
+            print(intrinsic)  # pragma: no cover
+            print('#####')  # pragma: no cover
+            print('Expected Edges:')  # pragma: no cover
+            print(expected_edges)  # pragma: no cover
+            print('Edges:')  # pragma: no cover
+            print(edges)  # pragma: no cover
+            raise  # pragma: no cover

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 import unittest
+from unittest.mock import patch, Mock, mock_open
 from parameterized import parameterized
-from dgraphpandas.config import get_from_config
+from dgraphpandas.config import get_from_config, _get_config
 
 
 class ConfigTests(unittest.TestCase):
@@ -51,3 +52,40 @@ class ConfigTests(unittest.TestCase):
         value = get_from_config(key, config, something_else='override', default='default_value')
 
         self.assertEqual(value, 'default_value')
+
+    def test_get_config_null_config(self):
+        '''
+        Ensures when the config is null
+        an exception is raised
+        '''
+        config = None
+        with self.assertRaises(ValueError):
+            _get_config(config)
+
+    @patch('builtins.open', callable=mock_open)
+    @patch('dgraphpandas.config.json.load')
+    def test_get_config_file(self, mock_json: Mock, mock_open: Mock):
+        '''
+        Ensures when a file (str) is passed, open is called and
+        a json is loaded
+        '''
+        config = 'my_config'
+        expected_config = {'my_config': 'hello'}
+        mock_json.return_value = expected_config
+
+        result = _get_config(config)
+
+        self.assertEqual(expected_config, result)
+
+        args, kwargs = mock_open.call_args_list[0]
+        self.assertEqual(args, (config, 'r'))
+        self.assertEqual(kwargs, {})
+
+    def test_get_config_passed(self):
+        '''
+        Ensures when an actual config is passed,
+        it is returned back
+        '''
+        config = {'my_config': 'hello'}
+        returned = _get_config(config)
+        self.assertEqual(config, returned)

--- a/tests/test_rdf.py
+++ b/tests/test_rdf.py
@@ -1,0 +1,310 @@
+import unittest
+from unittest.mock import MagicMock, Mock, patch, call
+from parameterized import parameterized
+import pandas as pd
+from pandas.testing import assert_frame_equal
+from dgraphpandas.rdf import _resolve_transform, to_rdf
+from dgraphpandas.strategies.horizontal import horizontal_transform
+from dgraphpandas.strategies.vertical import vertical_transform
+
+
+class RdfTests(unittest.TestCase):
+
+    def test_resolve_transform_null_parameter(self):
+        '''
+        Ensures when the config is null
+        an error is raised
+        '''
+        config = None
+        with self.assertRaises(ValueError):
+            _resolve_transform(config)
+
+    def test_resolve_transform_horizontal(self):
+        '''
+        Ensures when transform is set to horizontal,
+        then a horizontal is returned
+        '''
+        config = {'transform': 'horizontal'}
+        transform_func = _resolve_transform(config)
+        self.assertEqual(transform_func, horizontal_transform)
+
+    def test_resolve_transform_vertical(self):
+        '''
+        Ensures when transform is set to vertical,
+        then a vertical is returned
+        '''
+        config = {'transform': 'vertical'}
+        transform_func = _resolve_transform(config)
+        self.assertEqual(transform_func, vertical_transform)
+
+    def test_resolve_transform_unknown(self):
+        '''
+        Ensures when the transform is unknown,
+        then the default horizontal is used
+        '''
+        config = {'transform': 'something'}
+        transform_func = _resolve_transform(config)
+        self.assertEqual(transform_func, horizontal_transform)
+
+    def test_resolve_transform_none_provided(self):
+        '''
+        Ensures when no transform is provided,
+        then the default horizontal is used
+        '''
+        config = {}
+        transform_func = _resolve_transform(config)
+        self.assertEqual(transform_func, horizontal_transform)
+
+    @parameterized.expand([
+        (None, {'transform': 'horizontal'}, 'key'),
+        (pd.DataFrame(), None, 'key'),
+        (pd.DataFrame(), {'transform': 'horizontal'}, None)
+    ])
+    def test_to_rdf_null_parameters(self, frame, config, key):
+        '''
+        Ensures when parameters are null then an exception
+        is thrown
+        '''
+        with self.assertRaises(ValueError):
+            to_rdf(frame, config, key)
+
+    @parameterized.expand([
+        ('with_export_csv', {'export_csv': True}),
+        ('with_export_rdf', {'export_rdf': True}),
+    ])
+    @patch('dgraphpandas.rdf.generate_upserts')
+    @patch('dgraphpandas.rdf._get_config')
+    @patch('dgraphpandas.rdf._resolve_transform')
+    @patch('dgraphpandas.rdf.pd.read_csv')
+    @patch('dgraphpandas.rdf.gzip.open')
+    @patch('dgraphpandas.rdf.os.makedirs')
+    def test_to_rdf_from_memory_frame_non_output_dir(
+            self,
+            name,
+            options,
+            mock_os_makedirs: Mock,
+            mock_gzip: Mock,
+            mock_pandas_read_csv_mock: Mock,
+            mock_transform_func: Mock,
+            mock_config: Mock,
+            mock_upsert: Mock):
+        '''
+        Ensures when a memory frame is passed, it is passed through
+        transformations and nothing is written to disk
+        when output_dir is none even if the export params are set.
+        '''
+        frame = pd.DataFrame(data={
+            'subject': [1, 2, 3],
+            'predicate': ['age']*3,
+            'object': [23, 43, 12]
+        })
+        config = {
+            'transform': 'horizontal',
+            'files': {'my_file': {
+                'subject_fields': ['id']
+            }}
+        }
+        config_key = 'my_file'
+
+        mock_config.return_value = config
+        mock_transform = MagicMock(return_value=(1, 2))
+        mock_transform_func.return_value = mock_transform
+        mock_upsert.return_value = (['intrinsic'], ['edges'])
+
+        result = to_rdf(frame, config, config_key, output_dir=None, **(options))
+        self.assertEqual(result, (['intrinsic'], ['edges']))
+
+        args, kwargs = mock_config.call_args_list[0]
+        self.assertEqual(args, (config,))
+        self.assertEqual(kwargs, {})
+
+        args, kwargs = mock_transform.call_args_list[0]
+        passed_frame = args[0]
+        passed_config = args[1]
+        passed_key = args[2]
+
+        assert_frame_equal(frame, passed_frame)
+        self.assertEqual(config, passed_config)
+        self.assertEqual(config_key, passed_key)
+        self.assertEqual(kwargs, options)
+
+        mock_pandas_read_csv_mock.assert_not_called()
+        mock_gzip.assert_not_called()
+        mock_os_makedirs.assert_not_called()
+
+    @parameterized.expand([
+        ###
+        (
+            'with_export_csv',
+            [
+                pd.DataFrame(data={
+                    'subject': [1, 2, 3],
+                    'predicate': ['age']*3,
+                    'object': [23, 43, 12]
+                })
+            ],
+            {
+                'transform': 'horizontal',
+                'files': {
+                    'my_file': {
+                        'subject_fields': ['id']
+                    }
+                }
+            },
+            'my_file',
+            {'export_csv': True}
+        ),
+        ###
+        (
+            'with_export_rdf',
+            [
+                pd.DataFrame(data={
+                    'subject': [1, 2, 3],
+                    'predicate': ['age']*3,
+                    'object': [23, 43, 12]
+                })
+            ],
+            {
+                'transform': 'horizontal',
+                'files': {
+                    'my_file': {
+                        'subject_fields': ['id']
+                    }
+                }
+            },
+            'my_file',
+            {'export_rdf': True}
+        ),
+        ###
+        (
+            'with_both_csv_and_rdf',
+            [
+                pd.DataFrame(data={
+                    'subject': [1, 2, 3],
+                    'predicate': ['age']*3,
+                    'object': [23, 43, 12]
+                })
+            ],
+            {
+                'transform': 'horizontal',
+                'files': {
+                    'my_file': {
+                        'subject_fields': ['id']
+                    }
+                }
+            },
+            'my_file',
+            {'export_rdf': True, 'export_csv': True}
+        ),
+        ###
+        (
+            'with_console',
+            [
+                pd.DataFrame(data={
+                    'subject': [1, 2, 3],
+                    'predicate': ['age']*3,
+                    'object': [23, 43, 12]
+                })
+            ],
+            {
+                'transform': 'horizontal',
+                'files': {
+                    'my_file': {
+                        'subject_fields': ['id']
+                    }
+                }
+            },
+            'my_file',
+            {'console': True}
+        ),
+        ###
+        (
+            'multiple_chunks',
+            [
+                pd.DataFrame(data={
+                    'subject': [4, 5, 6],
+                    'predicate': ['age']*3,
+                    'object': [23, 43, 12]
+                }),
+
+                pd.DataFrame(data={
+                    'subject': [1, 2, 3],
+                    'predicate': ['age']*3,
+                    'object': [23, 43, 12]
+                })
+            ],
+            {
+                'transform': 'horizontal',
+                'files': {
+                    'my_file': {
+                        'subject_fields': ['id']
+                    }
+                }
+            },
+            'my_file',
+            {'export_rdf': True, 'export_csv': True}
+        ),
+    ])
+    @patch('dgraphpandas.rdf.generate_upserts')
+    @patch('dgraphpandas.rdf._get_config')
+    @patch('dgraphpandas.rdf._resolve_transform')
+    @patch('dgraphpandas.rdf.pd.read_csv')
+    @patch('dgraphpandas.rdf.gzip.open')
+    @patch('dgraphpandas.rdf.os.makedirs')
+    @patch('builtins.print')
+    def test_to_rdf_from_file(
+            self,
+            name,
+            frames,
+            config,
+            config_key,
+            options,
+            mock_print: Mock,
+            mock_os_makedirs: Mock,
+            mock_gzip: Mock,
+            mock_pandas_read_csv_mock: Mock,
+            mock_transform_func: Mock,
+            mock_config: Mock,
+            mock_upsert: Mock):
+        '''
+        Ensures when a file is provided, then transform is called
+        '''
+        mock_pandas_read_csv_mock.return_value = frames
+        mock_config.return_value = config
+        mock_intrinsic = MagicMock(spec=pd.DataFrame)
+        mock_edges = MagicMock(spec=pd.DataFrame)
+        mock_transform = MagicMock(return_value=(mock_intrinsic, mock_edges))
+        mock_transform_func.return_value = mock_transform
+        mock_upsert.return_value = (['intrinsic'], ['edges'])
+
+        result = to_rdf('my_file.csv', config, config_key, output_dir='data/', **(options))
+        self.assertEqual(result, [(['intrinsic'], ['edges'])]*len(frames))
+
+        args, kwargs = mock_pandas_read_csv_mock.call_args_list[0]
+        self.assertEqual(('my_file.csv',), args)
+        self.assertEqual({'chunksize': 10_000_000}, kwargs)
+        self.assertEqual(call('data/', exist_ok=True), mock_os_makedirs.call_args_list[0])
+
+        if 'export_csv' in options:
+            self.assertEqual(len(frames), len(mock_intrinsic.method_calls))
+            self.assertEqual(len(frames), len(mock_edges.method_calls))
+            self.assertEqual(mock_intrinsic.method_calls[0], call.to_csv('data/my_file_intrinsic.csv', encoding='utf-8', index=False))
+            self.assertEqual(mock_edges.method_calls[0], call.to_csv('data/my_file_edges.csv', encoding='utf-8', index=False))
+        else:
+            self.assertEqual(0, len(mock_intrinsic.method_calls))
+            self.assertEqual(0, len(mock_edges.method_calls))
+
+        if 'export_rdf' in options:
+            self.assertEqual(len(frames)*2, len(mock_gzip.call_args_list))
+            self.assertEqual(call('data/my_file_intrinsic.gz', compresslevel=9, mode='wb'), mock_gzip.call_args_list[0])
+            self.assertEqual(call('data/my_file_edges.gz', compresslevel=9, mode='wb'), mock_gzip.call_args_list[1])
+        else:
+            self.assertEqual(0, len(mock_gzip.call_args_list))
+
+        if 'console' in options:
+            mock_print.assert_called()
+
+        mock_config.assert_called()
+        mock_transform.assert_called()
+        mock_transform_func.assert_called()
+        mock_upsert.assert_called()


### PR DESCRIPTION
## Changes

- Centralized logic into `to_rdf` and exposed on package level 
- Added `get_config` method
- Updated Assertion helper logic to have no coverage
- Updated `__main__` to use `to_rdf`
