### PR TITLE
fix(pandas): update compatibility

### DIFF
--- a/dgraphpandas/__init__.py
+++ b/dgraphpandas/__init__.py
@@ -1,5 +1,5 @@
 __name__ = 'dgraphpandas'
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 __description__ = 'Transform Pandas DataFrames into Exports to be sent to DGraph'
 
 from dgraphpandas.rdf import to_rdf  # noqa

--- a/dgraphpandas/strategies/schema.py
+++ b/dgraphpandas/strategies/schema.py
@@ -139,6 +139,7 @@ def create_schema(source_config: Union[str, Dict[str, Any]], output_dir='.', **k
     if ensure_xid_predicate:
         # Create a new DataFrame for the row to be added
         new_row = pd.DataFrame([{'column': 'xid', 'type': 'string', 'table': None, 'options': '@index(exact)'}])
+        # Use pd.concat to add the new row
         frame = pd.concat([frame, new_row], ignore_index=True)
 
     frame.sort_values(by=['table', 'type'], inplace=True)

--- a/dgraphpandas/strategies/schema.py
+++ b/dgraphpandas/strategies/schema.py
@@ -137,7 +137,9 @@ def create_schema(source_config: Union[str, Dict[str, Any]], output_dir='.', **k
 
     logger.debug('Appending xid declaration')
     if ensure_xid_predicate:
-        frame = frame.append({'column': 'xid', 'type': 'string', 'table': None, 'options': '@index(exact)'}, ignore_index=True)
+        # Create a new DataFrame for the row to be added
+        new_row = pd.DataFrame([{'column': 'xid', 'type': 'string', 'table': None, 'options': '@index(exact)'}])
+        frame = pd.concat([frame, new_row], ignore_index=True)
 
     frame.sort_values(by=['table', 'type'], inplace=True)
     frame.reset_index(inplace=True, drop=True)


### PR DESCRIPTION
## Summary
- Update to the schema generation for Pandas Update Compatibility.

## Changes
- Instead of directly appending a dictionary to the DataFrame, create a new DataFrame (`new_row`) that contains the data to add.
- Use `pd.concat()` to concatenate the original DataFrame (`frame`) with the new DataFrame (`new_row`).
  - The `ignore_index=True` parameter ensures the index is reset after concatenation.