### PR TITLE
chore(python): remove unsupported versions and restrict core deps

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        # https://devguide.python.org/versions/
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
-        flake8 . --show-source --count
+        flake8 . --show-source --count --exclude .venv
     - name: Unit Test
       run: |
         pytest

--- a/dgraphpandas/__init__.py
+++ b/dgraphpandas/__init__.py
@@ -1,5 +1,5 @@
 __name__ = 'dgraphpandas'
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 __description__ = 'Transform Pandas DataFrames into Exports to be sent to DGraph'
 
 from dgraphpandas.rdf import to_rdf  # noqa

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-pandas
+pandas<2
+numpy<2

--- a/tests/strategies/test_horizontal.py
+++ b/tests/strategies/test_horizontal.py
@@ -435,7 +435,7 @@ class HorizontalTests(unittest.TestCase):
             pd.DataFrame(data={
                 'customer_id': [1, 2, 1, 2],
                 'predicate': ['dob', 'dob', 'weight', 'weight'],
-                'object':[pd.to_datetime('2021-03-02 00:00:00'), pd.to_datetime('1945-03-01 00:00:00'), 50, 32]
+                'object': [pd.to_datetime('2021-03-02 00:00:00'), pd.to_datetime('1945-03-01 00:00:00'), 50, 32]
             })
         ),
         ###


### PR DESCRIPTION
## Summary

Update Supported Python Versions, Restrict Core Dependency versions, Fix Styling Issues

## Changes

* During contribution https://github.com/kiran94/dgraphpandas/pull/28, found that CI was [failing](https://github.com/kiran94/dgraphpandas/actions/runs/12386267716/job/34581993532?pr=28) due to that python version coming [out of support](https://devguide.python.org/versions/). So in this change we are updating the CI to be the minimum supported version 
* Restrict pandas and numpy to `<2` (since this package was first developed, those major releases have introduced some incompatibilities
* Fixed minor styling issues 